### PR TITLE
Lock grape-jsonapi gem version to fix malformed Swagger docs

### DIFF
--- a/bullet_train-api.gemspec
+++ b/bullet_train-api.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 7.0.0"
   spec.add_dependency "grape", "~> 1.6.0"
   spec.add_dependency "grape-cancan"
-  spec.add_dependency "grape-jsonapi"
+  # grape-jsonapi 1.0.1 introduced a data param "feature" that causes malformed Swagger docs
+  spec.add_dependency "grape-jsonapi", "1.0.0"
   spec.add_dependency "grape-swagger"
   spec.add_dependency "grape_on_rails_routes"
   # We can't do this until there is an updated release.


### PR DESCRIPTION
The **grape-jsonapi gem** introduced a data param "feature" in v1.0.1 that breaks the Swagger doc generation by forcefully wrapping the Swagger JSON in an additional (invalid) `data` param.

This PR locks the gem version to 1.0.0 to bypass this bug.