### PR TITLE
Refactor /me API endpoint + add localization

### DIFF
--- a/app/controllers/api/v1/me_endpoint.rb
+++ b/app/controllers/api/v1/me_endpoint.rb
@@ -1,8 +1,9 @@
 class Api::V1::MeEndpoint < Api::V1::Root
-  resource :me do
+  resource :me, desc: Api.title(:actions) do
+    desc Api.title(:show), &Api.show_desc
     oauth2
-    get "/" do
-      render Api::V1::UserSerializer.new(current_user, include: [:teams, :memberships]).to_json
+    get do
+      render current_user, include: [:teams, :memberships], serializer: "Api::V1::UserSerializer", adapter: :attributes
     end
   end
 end

--- a/config/locales/en/me.en.yml
+++ b/config/locales/en/me.en.yml
@@ -1,0 +1,5 @@
+en:
+  me: &me
+  	api:
+	  actions: "Actions for the current user"
+	  show: "Retrieve info about the current user"


### PR DESCRIPTION
Refactors the `/me` endpoint to resolve the same bug that [malformed the Swagger docs](https://github.com/bullet-train-co/bullet_train-api/pull/7). Also adds localization.