### PR TITLE
Exclude abstract concepts from API when HIDE_THINGS is true

### DIFF
--- a/app/controllers/concerns/api/v1/base.rb
+++ b/app/controllers/concerns/api/v1/base.rb
@@ -15,7 +15,9 @@ module Api::V1::Base
     end
 
     BulletTrain::Api.endpoints.each do |endpoint_class|
-      mount endpoint_class.constantize
+      unless scaffolding_things_disabled? && endpoint_class.match?(/Api::V1::Scaffolding/)
+        mount endpoint_class.constantize
+      end
     end
 
     after_validation do

--- a/app/serializers/concerns/api/v1/teams/serializer_base.rb
+++ b/app/serializers/concerns/api/v1/teams/serializer_base.rb
@@ -11,6 +11,8 @@ module Api::V1::Teams::SerializerBase
       :created_at,
       :updated_at
 
-    has_many :scaffolding_absolutely_abstract_creative_concepts, serializer: Api::V1::Scaffolding::AbsolutelyAbstract::CreativeConceptSerializer
+    unless scaffolding_things_disabled?
+      has_many :scaffolding_absolutely_abstract_creative_concepts, serializer: Api::V1::Scaffolding::AbsolutelyAbstract::CreativeConceptSerializer
+    end
   end
 end


### PR DESCRIPTION
Context: https://discord.com/channels/836637622432170028/836637623048601633/974732999365115914

This makes sure Creative Concepts and Tangible Things don't show up in the swagger docs.

I also noticed that running certain tests while setting `HIDE_THINGS` to `true` fails on a clean slate. This will at least take care of the Teams endpoint test (`test/controllers/api/v1/teams_endpoint_test.rb`), since the tests weren't returning a 200 response with `HIDE_THINGS` on.

There a couple of other tests that fail when `HIDE_THINGS` is `true`, but it's unrelated to `bullet_train-api` so I plan on opening another PR in the starter repo.