### PR TITLE
Throw error properly when user isn't authorized to perform API action

### DIFF
--- a/app/controllers/api/v1/loads_and_authorizes_api_resource.rb
+++ b/app/controllers/api/v1/loads_and_authorizes_api_resource.rb
@@ -24,7 +24,7 @@ module Api::V1::LoadsAndAuthorizesApiResource
           resource_type = api_resource_param_id.present? ? :single_record : :collection
           resources = api_resource_class.accessible_by(current_ability, permission)
 
-          # If there no other ids (i.e. if we're doing a `show` action),
+          # If there are no other ids (i.e. if we're doing a `show` action),
           # we simply get the original resources array.
           all_accessible_api_resources = resources.where(api_resource_params_other_ids)
           raise CanCan::AccessDenied if all_accessible_api_resources.empty?

--- a/app/controllers/api/v1/loads_and_authorizes_api_resource.rb
+++ b/app/controllers/api/v1/loads_and_authorizes_api_resource.rb
@@ -20,22 +20,31 @@ module Api::V1::LoadsAndAuthorizesApiResource
           /_id$/i.match?(param)
         }
 
-        all_accessible_api_resources = api_resource_class.accessible_by(current_ability, permission)
+        unless permission.eql? :create
+          resource_type = api_resource_param_id.present? ? :single_record : :collection
+          resources = api_resource_class.accessible_by(current_ability, permission)
 
-        if api_resource_param_id.present? # :read, :update, :delete
+          # If there no other ids (i.e. if we're doing a `show` action),
+          # we simply get the original resources array.
+          all_accessible_api_resources = resources.where(api_resource_params_other_ids)
+          raise CanCan::AccessDenied if all_accessible_api_resources.empty?
+        end
+
+        if resource_type == :single_record # :show, :update, :destroy
           instance_variable_set(instance_variable_name, all_accessible_api_resources.find(api_resource_param_id))
-        elsif permission.eql? :create
-          instance_variable_set(instance_variable_name, api_resource_class.new(api_resource_params))
-        elsif permission.eql? :read
-          all_accessible_api_resources = all_accessible_api_resources.where(api_resource_params_other_ids) if api_resource_params_other_ids.present?
+        elsif resource_type == :collection # index
           instance_variable_set(instance_variable_collection_name, all_accessible_api_resources)
           skip_authorize = true # can't use CanCan to authorize collections
+        elsif permission.eql? :create
+          instance_variable_set(instance_variable_name, api_resource_class.new(api_resource_params))
         end
 
         eval "authorize! :#{permission}, #{instance_variable_name}" unless skip_authorize
       rescue ActiveRecord::RecordNotFound
         # the default RecordNotFound message includes the raw SQL... which feels bad
         handle_api_error(ActiveRecord::RecordNotFound.new("The id #{api_resource_param_id} could not be found."))
+      rescue CanCan::AccessDenied
+        handle_api_error(CanCan::AccessDenied.new("You are not authorized to access this data.", permission, api_resource_class))
       end
     end
   end


### PR DESCRIPTION
This PR addresses the `:forbidden` status-related TODOs in the endpoint tests over in the starter repo.
Joint PR → [bullet_train#260](https://github.com/bullet-train-co/bullet_train/pull/260)

## Details

I worked on this back before the Great Unbundling in [this PR](https://github.com/bullet-train-co/bullet-train-tailwind-css/pull/192) and I legit wrote this code? :man_facepalming:
```ruby
if api_resource_param_id.present? # :read, :update, :delete
  api_resource_class.find(api_resource_param_id)
else # index
  api_resource_class.where(api_resource_params_other_ids)
end
```
No substitution to be found...

Anyways, I hope this PR's code is more readable, so feel free to use this fix if it works for you.
