### PR TITLE
Raise error for all other cases in `handle_api_error`

### DIFF
--- a/app/controllers/api/v1/exceptions_handler.rb
+++ b/app/controllers/api/v1/exceptions_handler.rb
@@ -38,6 +38,8 @@ module Api::V1::ExceptionsHandler
             "Access-Control-Allow-Origin" => "*",
             "Access-Control-Request-Method" => "*"
           }).finish
+
+          raise error
         end
       end
 


### PR DESCRIPTION
Closes #13.

## History
This one had been brought up way back [before the Great Unbundling](https://github.com/bullet-train-co/bullet-train-tailwind-css/issues/230) and it unfortunately went under the radar for a while, and we simply weren't raising an error when we got to this point in the code. As you can see in the comments in that issue, someone mentioned that Grape has a "catch-all handler by design," and I was also curious as to how to handle the situation.

## Handling errors with precision in Grape
Digging through things a little more, I see that although the docs provide an [example for covering all errors like in the ruby block I have written below](https://github.com/ruby-grape/grape#exception-handling), they also mention this: 
> This mimics [default rescue behaviour](https://ruby-doc.org/core/StandardError.html) when an exception type is not provided. Any other exception should be rescued explicitly

I'm personally not too keen on putting a `StandardError` blanket on all our errors if we <i>can</i> define them explicitly. Here's what we currently have in `app/controllers/concerns/api/v1/base.rb`:
```ruby
rescue_from :all do |error|
  handle_api_error(error)
end
```

Granted, we do have an `if` statement in `handle_api_error` to handle any common exceptions so it's probably not pressing, but I'm curious if this is something we want to change for clarity's sake, or just leave it as is.

Either way, with this fix, errors should be getting raised now whenever one is picked up in the endpoint tests in the main app.