### PR TITLE
Set current context to `:api`

### DIFF
--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -23,9 +23,4 @@ class Api::Base < Grape::API
       description: I18n.t("application.description")
     },
     mount_path: "/docs/swagger"
-
-  # TODO Reintroduce this once we've got `context` in current attributes.
-  # before do
-  #   Current.context = :api
-  # end
 end

--- a/app/controllers/api/v1/defaults.rb
+++ b/app/controllers/api/v1/defaults.rb
@@ -5,6 +5,7 @@ module Api::V1::Defaults
     before do
       header["Access-Control-Allow-Origin"] = "*"
       header["Access-Control-Request-Method"] = "*"
+      Current.context = :api
     end
 
     helpers do


### PR DESCRIPTION
I was confused with this one for a bit, but eventually found `Current` in [bullet_train-base](https://github.com/bullet-train-co/bullet_train-base/blob/8938e65e434398a057dee23316944b42e074da24/app/models/concerns/current_attributes/base.rb#L5) and how it has the `context` attribute:
```ruby
module CurrentAttributes::Base
  extend ActiveSupport::Concern

  included do
    attribute :user, :team, :membership, :ability, :context

    resets do
      Time.zone = nil
    end
  end

 # etc...
end
```

The `before` block in the API base controller wasn't being run, so I thought putting `Current.context = :api` here in the defaults made the most sense.

## `Current`'s state

From `ActiveSupport::CurrentAttributes`:
> Abstract super class that provides a thread-isolated attributes singleton, which resets automatically before and after each request. This allows you to keep all the per-request attributes easily available to the whole system.

Therefore `Current.context` is set to `:api` only for the life cycle of the request, so although `Current.context` will return `nil` in, for example, the teams endpoint tests, it will return `:api` from within `bullet_train-api`-specific methods like `load_and_authorize_api_resource` and `handle_api_error`.

## Previous commit
Just in case we wanted to keep track, here's the initial commit where the commented out section was added:
https://github.com/bullet-train-co/bullet_train-api/commit/3ea80ebc9bb7ff68e8b20b1c1a4ba88f79c5317d