### PR TITLE
Add spring before Super Scaffolding test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,7 @@ jobs:
 
       - *wait_for_docker
 
+      - run: "cd tmp/starter && bundle add spring"
       - run:
           name: 'Setup Super Scaffolding System Test'
           command: "cd tmp/starter && bundle exec test/bin/setup-super-scaffolding-system-test"


### PR DESCRIPTION
This should make sure our Super Scaffolding system tests pass.