### PR TITLE
Determine current version dynamically in base API module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,7 @@ jobs:
 
       - *wait_for_docker
 
+      - run: "cd tmp/starter && bundle add spring"
       - run:
           name: 'Setup Super Scaffolding System Test'
           command: "cd tmp/starter && bundle exec test/bin/setup-super-scaffolding-system-test"

--- a/app/controllers/api.rb
+++ b/app/controllers/api.rb
@@ -17,13 +17,13 @@ module Api
   def self.serializer
     path = find_path
     version_in_path = path.scan(/\/v\d*\//).first
-    version = version_in_path.gsub(/\//, "").upcase
+    version = version_in_path.delete("/").upcase
     version ||= "V1"
     "Api::#{version}::#{Api.topic.classify}Serializer"
   end
 
   def self.current_version
-    self.topic
+    topic
   end
 
   def self.status(code)
@@ -41,9 +41,9 @@ module Api
   def self.find_path
     caller.find do |path|
       (path.include?("controllers/api") || path.include?("app/controllers/concerns/api")) &&
-      !path.include?("app/controllers/api.rb") &&
-      !path.include?("app/controllers/api/v1/root.rb") &&
-      !path.include?("app/controllers/api/base.rb")
+        !path.include?("app/controllers/api.rb") &&
+        !path.include?("app/controllers/api/v1/root.rb") &&
+        !path.include?("app/controllers/api/base.rb")
     end
   end
 


### PR DESCRIPTION
Addresses the TODO in `app/controllers/api.rb`

since the path has the version in the string, I pulled `/v1/` from it and injected it into the serializer string.

This repository wasn't installing `spring` when running the Super Scaffolding system tests, so I went ahead and added that here too.