### PR TITLE
Remove `UserSerializer` specification from `Me` endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,7 @@ jobs:
 
       - *wait_for_docker
 
+      - run: "cd tmp/starter && bundle add spring"
       - run:
           name: 'Setup Super Scaffolding System Test'
           command: "cd tmp/starter && bundle exec test/bin/setup-super-scaffolding-system-test"

--- a/app/controllers/api/v1/me_endpoint.rb
+++ b/app/controllers/api/v1/me_endpoint.rb
@@ -3,7 +3,7 @@ class Api::V1::MeEndpoint < Api::V1::Root
     desc Api.title(:show), &Api.show_desc
     oauth2
     get do
-      render current_user, include: [:teams, :memberships], serializer: "Api::V1::UserSerializer", adapter: :attributes
+      render current_user, include: [:teams, :memberships], adapter: :attributes
     end
   end
 end


### PR DESCRIPTION
I gave a look into this TODO in the `Me` serializer:
```ruby
# TODO This serializer only needs to exist because of a limitation in `Api.show_desc` that we use in
# `app/controllers/api/v1/me_endpoint.rb`. This is the easiest solution at the moment, but we can revisit later.
class Api::V1::MeSerializer < Api::V1::UserSerializer
end
```

I read through #8 a bit, but at this point I think I just don't know enough about Grape to adjust DSL lines like `&Api.show_desc` properly.

Is the `Me` endpoint there just so we can return the current user's data?
Should this be tested before moving forward?

## Changes
`MeSerializer` is inheriting `UserSerializer`, but it's not adding any attributes, so I figured we could delete the string I deleted here in the PR. We still need the serializer itself though, I'm assuming just because the `Me` endpoint itself exists (I didn't find any invocations of the serializer anywhere else).

With the option I've deleted, we get this under `definitions` in the docs:
![Screenshot from 2022-08-26 09-24-30](https://user-images.githubusercontent.com/10546292/186791747-394aaadf-5821-495d-a2f6-5c2bf9a5b035.png)

