### PR TITLE
Create `bump_version` rake task

### DIFF
--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -1,5 +1,6 @@
 namespace :bullet_train do
   namespace :api do
+    desc "Bump the current version of application's API"
     task :bump_version do
       # Calculate new version.
       initializer_content = File.new("config/initializers/api.rb").readline

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -1,4 +1,15 @@
-# desc "Explaining what the task does"
-# task :bullet_train_api do
-#   # Task goes here
-# end
+namespace :bullet_train do
+  namespace :api do
+    task :bump_version do
+      # Calculate new version.
+      initializer_content = File.new("config/initializers/api.rb").readline
+      previous_version = initializer_content.scan(/v\d+/).pop
+      new_version = "v#{previous_version.scan(/\d+/).pop.to_i + 1}"
+
+      # Update initializer.
+      File.open("config/initializers/api.rb", "w") do |f|
+        f.write(initializer_content.gsub(previous_version, new_version))
+      end
+    end
+  end
+end

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -1,3 +1,6 @@
+require "scaffolding"
+require "scaffolding/file_manipulator"
+
 namespace :bullet_train do
   namespace :api do
     desc "Bump the current version of application's API"
@@ -52,8 +55,7 @@ namespace :bullet_train do
             new_hierarchy
           end
         end
-        # TODO: I'd like to use Scaffolding::FileManipulator for this.
-        File.write(new_file_name, updated_file_contents.join)
+        Scaffolding::FileManipulator.write(new_file_name, updated_file_contents)
       end
 
       # Here we make sure config/api/#{new_version}.rb is called from within the main routes file.
@@ -66,8 +68,7 @@ namespace :bullet_train do
           line
         end
       end
-      # TODO: I'd like to use Scaffolding::FileManipulator for this.
-      File.write("config/routes.rb", updated_file_contents.join)
+      Scaffolding::FileManipulator.write("config/routes.rb", updated_file_contents)
 
       puts "Finished bumping to #{new_version}"
     end

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -7,9 +7,7 @@ namespace :bullet_train do
       new_version = "v#{previous_version.scan(/\d+/).pop.to_i + 1}"
 
       # Update initializer.
-      File.open("config/initializers/api.rb", "w") do |f|
-        f.write(initializer_content.gsub(previous_version, new_version))
-      end
+      File.write("config/initializers/api.rb", initializer_content.gsub(previous_version, new_version))
 
       [
         "app/controllers/api/#{new_version}",
@@ -22,8 +20,8 @@ namespace :bullet_train do
       files_to_update = [
         "config/routes/api/#{previous_version}.rb",
         Dir.glob("app/controllers/api/#{previous_version}/**/*.rb") +
-        Dir.glob("app/views/api/#{previous_version}/**/*.json.jbuilder") +
-        Dir.glob("test/controllers/api/#{previous_version}/**/*.rb")
+          Dir.glob("app/views/api/#{previous_version}/**/*.json.jbuilder") +
+          Dir.glob("test/controllers/api/#{previous_version}/**/*.rb")
       ].flatten
 
       files_to_update.each do |file_name|
@@ -50,12 +48,12 @@ namespace :bullet_train do
             break if child_dir_or_file.match?(/\./)
 
             new_hierarchy = "#{base}/#{child_dir_or_file}"
-            Dir.mkdir(new_hierarchy) unless Dir.exists?(new_hierarchy)
+            Dir.mkdir(new_hierarchy) unless Dir.exist?(new_hierarchy)
             new_hierarchy
           end
         end
         # TODO: I'd like to use Scaffolding::FileManipulator for this.
-        File.open(new_file_name, "w") {|f| f.write(updated_file_contents.join)}
+        File.write(new_file_name, updated_file_contents.join)
       end
 
       # Here we make sure config/api/#{new_version}.rb is called from within the main routes file.
@@ -69,7 +67,7 @@ namespace :bullet_train do
         end
       end
       # TODO: I'd like to use Scaffolding::FileManipulator for this.
-      File.open("config/routes.rb", "w") {|f| f.write(updated_file_contents.join)}
+      File.write("config/routes.rb", updated_file_contents.join)
 
       puts "Finished bumping to #{new_version}"
     end

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -1,5 +1,3 @@
-require "pry"
-
 namespace :bullet_train do
   namespace :api do
     task :bump_version do

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -69,37 +69,6 @@ namespace :bullet_train do
       # TODO: I'd like to use Scaffolding::FileManipulator for this.
       File.write("config/routes.rb", updated_file_contents.join)
 
-      # Prepare directories for base controllers
-      [
-        "app/controllers/concerns/api/#{new_version}/teams",
-        "app/controllers/concerns/api/#{new_version}/users"
-      ].each do |base_controller_dir|
-        base_dir, dirs_to_create = base_controller_dir.split(/(?<=concerns)\//)
-        dirs_to_create.split("/").inject(base_dir) do |base, child_dir|
-          dir_to_create = "#{base}/#{child_dir}"
-          Dir.mkdir(dir_to_create) unless Dir.exists?(dir_to_create)
-          dir_to_create
-        end
-      end
-
-      # Add base controllers to new version directory in main Bullet Train application.
-      bt_api_package = `bundle show bullet_train-api`.chomp
-      [
-        "app/controllers/concerns/api/v1/teams/controller_base.rb",
-        "app/controllers/concerns/api/v1/users/controller_base.rb"
-      ].each do |file_name|
-        previous_file_contents = File.open("#{bt_api_package}/#{file_name}").readlines
-        new_file_name = file_name.gsub(/v1/, new_version)
-        updated_file_contents = previous_file_contents.map do |line|
-          if line.match?(/v1/)
-            line.gsub(/v1/, new_version)
-          else
-            line.gsub("Api::V1", "Api::#{new_version.upcase}")
-          end
-        end
-        File.write(new_file_name, updated_file_contents.join)
-      end
-
       puts "Finished bumping to #{new_version}"
     end
   end

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -38,8 +38,8 @@ namespace :bullet_train do
         end
 
         # We can't create new files unless each directory under #{api/previous_version}
-        # has been created. For example, we have to create the `projects` directory
-        # before we can create the file `api/v2/projects/pages.json.jbuilder.`
+        # has been created under the new api directory. For example, we have to create
+        # the `projects` directory before we can create the file `api/v2/projects/pages.json.jbuilder.`
         new_version_dir, dir_hierarchy = new_file_name.split(/(?<=#{new_version})\//)
         if dir_hierarchy.present? && dir_hierarchy.match?("/")
           dir_hierarchy = dir_hierarchy.split("/")

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -37,9 +37,9 @@ namespace :bullet_train do
           end
         end
 
-        # We have to account for any other directories that exist under #{api/previous_version}
-        # but haven't been created yet in #{api/new_version}
-        # i.e. - api/v2/projects/pages.json.jbuilder.
+        # We can't create new files unless each directory under #{api/previous_version}
+        # has been created. For example, we have to create the `projects` directory
+        # before we can create the file `api/v2/projects/pages.json.jbuilder.`
         new_version_dir, dir_hierarchy = new_file_name.split(/(?<=#{new_version})\//)
         if dir_hierarchy.present? && dir_hierarchy.match?("/")
           dir_hierarchy = dir_hierarchy.split("/")

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -1,3 +1,5 @@
+require "pry"
+
 namespace :bullet_train do
   namespace :api do
     task :bump_version do
@@ -10,6 +12,68 @@ namespace :bullet_train do
       File.open("config/initializers/api.rb", "w") do |f|
         f.write(initializer_content.gsub(previous_version, new_version))
       end
+
+      [
+        "app/controllers/api/#{new_version}",
+        "app/views/api/#{new_version}",
+        "test/controllers/api/#{new_version}"
+      ].each do |dir|
+        Dir.mkdir(dir)
+      end
+
+      files_to_update = [
+        "config/routes/api/#{previous_version}.rb",
+        Dir.glob("app/controllers/api/#{previous_version}/**/*.rb") +
+        Dir.glob("app/views/api/#{previous_version}/**/*.json.jbuilder") +
+        Dir.glob("test/controllers/api/#{previous_version}/**/*.rb")
+      ].flatten
+
+      files_to_update.each do |file_name|
+        previous_file_contents = File.open(file_name).readlines
+        new_file_name = file_name.gsub(previous_version, new_version)
+
+        # i.e. Api::V1::ApplicationController > Api::V2::ApplicationController.
+        updated_file_contents = previous_file_contents.map do |line|
+          if line.match?(previous_version)
+            line.gsub(previous_version, new_version)
+          else
+            line.gsub("Api::#{previous_version.upcase}", "Api::#{new_version.upcase}")
+          end
+        end
+
+        # We have to account for any other directories that exist under #{api/previous_version}
+        # but haven't been created yet in #{api/new_version}
+        # i.e. - api/v2/projects/pages.json.jbuilder.
+        new_version_dir, dir_hierarchy = new_file_name.split(/(?<=#{new_version})\//)
+        if dir_hierarchy.present? && dir_hierarchy.match?("/")
+          dir_hierarchy = dir_hierarchy.split("/")
+          dir_hierarchy.inject(new_version_dir) do |base, child_dir_or_file|
+            # Stop making new directories if the string has an extention like ".rb"
+            break if child_dir_or_file.match?(/\./)
+
+            new_hierarchy = "#{base}/#{child_dir_or_file}"
+            Dir.mkdir(new_hierarchy) unless Dir.exists?(new_hierarchy)
+            new_hierarchy
+          end
+        end
+        # TODO: I'd like to use Scaffolding::FileManipulator for this.
+        File.open(new_file_name, "w") {|f| f.write(updated_file_contents.join)}
+      end
+
+      # Here we make sure config/api/#{new_version}.rb is called from within the main routes file.
+      previous_file_contents = File.open("config/routes.rb").readlines
+      updated_file_contents = previous_file_contents.map do |line|
+        if line.match?("draw \"api/#{previous_version}\"")
+          new_version_draw_line = line.gsub(previous_version, new_version)
+          line + new_version_draw_line
+        else
+          line
+        end
+      end
+      # TODO: I'd like to use Scaffolding::FileManipulator for this.
+      File.open("config/routes.rb", "w") {|f| f.write(updated_file_contents.join)}
+
+      puts "Finished bumping to #{new_version}"
     end
   end
 end

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -29,7 +29,6 @@ namespace :bullet_train do
         previous_file_contents = File.open(file_name).readlines
         new_file_name = file_name.gsub(previous_version, new_version)
 
-        # i.e. Api::V1::ApplicationController > Api::V2::ApplicationController.
         updated_file_contents = previous_file_contents.map do |line|
           if line.match?(previous_version)
             line.gsub(previous_version, new_version)

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -69,6 +69,37 @@ namespace :bullet_train do
       # TODO: I'd like to use Scaffolding::FileManipulator for this.
       File.write("config/routes.rb", updated_file_contents.join)
 
+      # Prepare directories for base controllers
+      [
+        "app/controllers/concerns/api/#{new_version}/teams",
+        "app/controllers/concerns/api/#{new_version}/users"
+      ].each do |base_controller_dir|
+        base_dir, dirs_to_create = base_controller_dir.split(/(?<=concerns)\//)
+        dirs_to_create.split("/").inject(base_dir) do |base, child_dir|
+          dir_to_create = "#{base}/#{child_dir}"
+          Dir.mkdir(dir_to_create) unless Dir.exists?(dir_to_create)
+          dir_to_create
+        end
+      end
+
+      # Add base controllers to new version directory in main Bullet Train application.
+      bt_api_package = `bundle show bullet_train-api`.chomp
+      [
+        "app/controllers/concerns/api/v1/teams/controller_base.rb",
+        "app/controllers/concerns/api/v1/users/controller_base.rb"
+      ].each do |file_name|
+        previous_file_contents = File.open("#{bt_api_package}/#{file_name}").readlines
+        new_file_name = file_name.gsub(/v1/, new_version)
+        updated_file_contents = previous_file_contents.map do |line|
+          if line.match?(/v1/)
+            line.gsub(/v1/, new_version)
+          else
+            line.gsub("Api::V1", "Api::#{new_version.upcase}")
+          end
+        end
+        File.write(new_file_name, updated_file_contents.join)
+      end
+
       puts "Finished bumping to #{new_version}"
     end
   end


### PR DESCRIPTION
## Details
This works fine for newly Super Scaffold models:
```
> rails g model Project team:references title:string
> bin/super-scaffold crud Project Team title:text_field
> rails db:migrate

> rake bullet_train:api:bump_version
> bundle exec rails test test/controllers/api/v2/projects_controller_test.rb
🌱 Generating global seeds.
Run options: --seed 14932

# Running:

.....

Finished in 4.848087s, 1.0313 runs/s, 6.6005 assertions/s.
5 runs, 32 assertions, 0 failures, 0 errors, 0 skips
```

### Bullet Train base functionality
However, some of the routes and controllers are in `bullet_train-api` which affect any new version's routing. For example, v1 is declared in `bullet_train-api/config/routes.rb`:
```ruby
Rails.application.routes.draw do
  use_doorkeeper

  namespace :api do
    namespace :v1 do
      shallow do
        resources :users
        resources :teams do
          resources :invitations
          resources :memberships
          namespace :platform do
            resources :applications
          end
        end
      end
    end
  end
end
```

The following is in the API versioning docs:
> In order to reduce the surface area of legacy API controllers that you're maintaining, it might make sense in some cases to have an older versioned API controller simply inherit from a newer version or the current version of the same API controller. For example, this might make sense for endpoints that you know didn't have breaking changes across API versions.

This specifically talks about an older version inheriting from a new version, but I'm hoping I can figure out a way to simply refer back to the previous version for new API versions.

## A possible solution
Perhaps we can eject these files like we eject views from `bullet_train-themes-light` and update them to use the version we're bumping to.