### PR TITLE
Use locale to display when access token was last used

### DIFF
--- a/app/views/account/platform/access_tokens/_index.html.erb
+++ b/app/views/account/platform/access_tokens/_index.html.erb
@@ -36,16 +36,9 @@
                     <%= render "shared/tables/checkbox", object: access_token %>
                     <td><%= render 'shared/attributes/code', attribute: :token, secret: true %></td>
                     <td><%= render 'shared/attributes/text', attribute: :description %></td>
-                    <td>
-                      <% if access_token.last_used_at %>
-                        <%= render 'shared/attributes/date_and_time', attribute: :last_used_at %>
-                      <% else %>
-                        <% # TODO Make it so we can just define a `default` key for `last_used_at` in the locale file and it will us that when present. %>
-                        <%= t('.last_used_at', time: access_token.last_used_at.present? ? access_token.created_at.strftime("%B %-d, %Y") : t('.never')) %>
-                      <% end %>
-                    </td>
+                    <td><%= render 'shared/attributes/date_and_time', attribute: :last_used_at %></td>
                     <%# 🚅 super scaffolding will insert new fields above this line. %>
-                    <td><%= render 'shared/attributes/date_and_time', attribute: :created_at %></td>
+                    <td><%#= render 'shared/attributes/date_and_time', attribute: :created_at %></td>
                     <td class="buttons">
                       <% unless hide_actions %>
                         <% if can? :edit, access_token %>

--- a/app/views/account/platform/access_tokens/_index.html.erb
+++ b/app/views/account/platform/access_tokens/_index.html.erb
@@ -41,7 +41,7 @@
                         <%= render 'shared/attributes/date_and_time', attribute: :last_used_at %>
                       <% else %>
                         <% # TODO Make it so we can just define a `default` key for `last_used_at` in the locale file and it will us that when present. %>
-                        Never
+                        <%= t('.last_used_at', time: access_token.last_used_at.present? ? access_token.created_at.strftime("%B %-d, %Y") : t('.never')) %>
                       <% end %>
                     </td>
                     <%# 🚅 super scaffolding will insert new fields above this line. %>

--- a/app/views/account/platform/access_tokens/_index.html.erb
+++ b/app/views/account/platform/access_tokens/_index.html.erb
@@ -38,7 +38,7 @@
                     <td><%= render 'shared/attributes/text', attribute: :description %></td>
                     <td><%= render 'shared/attributes/date_and_time', attribute: :last_used_at %></td>
                     <%# 🚅 super scaffolding will insert new fields above this line. %>
-                    <td><%#= render 'shared/attributes/date_and_time', attribute: :created_at %></td>
+                    <td><%= render 'shared/attributes/date_and_time', attribute: :created_at %></td>
                     <td class="buttons">
                       <% unless hide_actions %>
                         <% if can? :edit, access_token %>

--- a/config/locales/en/platform/access_tokens.en.yml
+++ b/config/locales/en/platform/access_tokens.en.yml
@@ -69,8 +69,6 @@ en:
           description: You can use Access Tokens to allow %{application_name} to make requests to the API.
       fields: *fields
       buttons: *buttons
-      last_used_at: "%{time}"
-      never: Never
     show:
       section: "%{access_token_name}"
       header: Access Token Details

--- a/config/locales/en/platform/access_tokens.en.yml
+++ b/config/locales/en/platform/access_tokens.en.yml
@@ -70,7 +70,7 @@ en:
       fields: *fields
       buttons: *buttons
       last_used_at: "%{time}"
-      never: "Never"
+      never: Never
     show:
       section: "%{access_token_name}"
       header: Access Token Details

--- a/config/locales/en/platform/access_tokens.en.yml
+++ b/config/locales/en/platform/access_tokens.en.yml
@@ -69,6 +69,8 @@ en:
           description: You can use Access Tokens to allow %{application_name} to make requests to the API.
       fields: *fields
       buttons: *buttons
+      last_used_at: "%{time}"
+      never: "Never"
     show:
       section: "%{access_token_name}"
       header: Access Token Details


### PR DESCRIPTION
Addresses the TODO in `app/views/account/platform/access_tokens/_index.html.erb`.

Opening this as a draft because the date parsing should be localized as well. We should be able to use `display_date` in the [dates helper](https://github.com/bullet-train-co/bullet_train-base/blob/ea850f86cd98fcb78453c68b4d886b9f172d360e/app/helpers/account/dates_helper.rb), but I haven't quite figured it out yet.