### PR TITLE
Write out types in OpenAPI docs

### DIFF
--- a/app/controllers/api/open_api_controller.rb
+++ b/app/controllers/api/open_api_controller.rb
@@ -39,9 +39,9 @@ module OpenApiHelper
     type = attribute_data.nil? ? "string" : attribute_data.type
 
     attribute_block = <<~YAML
-    #{attribute}:
-      description: "#{heading}"
-      type: #{type}
+      #{attribute}:
+        description: "#{heading}"
+        type: #{type}
     YAML
     indent(attribute_block.chomp, 2)
   end

--- a/app/controllers/api/open_api_controller.rb
+++ b/app/controllers/api/open_api_controller.rb
@@ -32,15 +32,20 @@ module OpenApiHelper
 
   def attribute(attribute)
     heading = t("#{current_model.name.underscore.pluralize}.fields.#{attribute}.heading")
-    # TODO A lot of logic to be done here.
-    indent("#{attribute}:\n  description: \"#{heading}\"\n  type: string", 2)
-  end
+    attribute_data = current_model.columns_hash[attribute.to_s]
 
-  def parameter(attribute)
-    heading = t("#{current_model.name.underscore.pluralize}.fields.#{attribute}.heading")
-    # TODO A lot of logic to be done here.
-    indent("#{attribute}:\n  description: \"#{heading}\"\n  type: string", 2)
+    # TODO: File fields don't show up in the columns_hash. How should we handle these?
+    # Default to `string` when the type returns nil.
+    type = attribute_data.nil? ? "string" : attribute_data.type
+
+    attribute_block = <<~YAML
+    #{attribute}:
+      description: "#{heading}"
+      type: #{type}
+    YAML
+    indent(attribute_block.chomp, 2)
   end
+  alias_method :parameter, :attribute
 end
 
 class Api::OpenApiController < ApplicationController


### PR DESCRIPTION
Addresses the TODO in `app/controllers/api/open_api_controller.rb`.

## Details
I grabbed each attribute's type via the model's `columns_hash` method and wrote them out as is in the docs. The TODO said there's a lot of logic to be done here, so if there's anything else to take care of I'd be glad to look into it.

## File Fields
File fields don't show up in `columns_hash`, so I wasn't quite sure how to grab the proper type for them, and I just ended up defaulted to using `string`.