### PR TITLE
Define User strong parameters based on attributes being updated

### DIFF
--- a/app/controllers/concerns/api/v1/users/controller_base.rb
+++ b/app/controllers/concerns/api/v1/users/controller_base.rb
@@ -4,13 +4,25 @@ module Api::V1::Users::ControllerBase
   module StrongParameters
     # Only allow a list of trusted parameters through.
     def user_params
+      general_fields = if params["commit"] == "Update Password"
+        [
+          :password,
+          :current_password,
+          :password_confirmation
+        ]
+      else
+        [
+          :email,
+          :first_name,
+          :last_name,
+          :time_zone,
+          :locale
+        ]
+      end
+
       strong_params = params.require(:user).permit(
         *permitted_fields,
-        :email,
-        :first_name,
-        :last_name,
-        :time_zone,
-        :locale,
+        *general_fields,
         # 🚅 super scaffolding will insert new fields above this line.
         *permitted_arrays,
         # 🚅 super scaffolding will insert new arrays above this line.


### PR DESCRIPTION
Addresses the TODO in the Joint PR so we can include `strong_parameters_from_api` in the User controller base in `bullet_train-base`.

Joint PR
- https://github.com/bullet-train-co/bullet_train-base/pull/124

Tests were failing because of how Devise handles strong parameters for updating a user password as opposed to updating general user information. Using `action_name == "update"` wasn't enough, so I went with params["commit"], and that enables us to pinpoint which attributes are needed to process the strong params.

I've included `permitted_fields` and `permitted_arrays` here for both instances, but if we should only allow it for updating general user information, I'll go ahead and change that if needed.