### PR TITLE
Add Field controller support to API controllers

### DIFF
--- a/app/controllers/concerns/api/controllers/base.rb
+++ b/app/controllers/concerns/api/controllers/base.rb
@@ -13,6 +13,7 @@ module Api::Controllers::Base
     helper ApplicationHelper
 
     include LoadsAndAuthorizesResource
+    include Fields::ControllerSupport
     include Pagy::Backend
 
     before_action :set_default_response_format


### PR DESCRIPTION
As I was working on https://github.com/bullet-train-pro/bullet_train-action_models/pull/19, I noticed that the API controller I was generating didn't recognize methods like `assign_boolean`. Since we're putting strong parameters in the API controllers, I think we'll need to this here to access all the different `assign` methods `bullet_train-fields` has.