### PR TITLE
Add `rake bullet_train:api:push_to_redocly` task

### DIFF
--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -2,8 +2,48 @@ namespace :bullet_train do
   namespace :api do
     desc "Registers your production API documentation to Redocly"
     task :push_to_redocly do
-      # TODO: Generate yaml file with ENV["BASE_URL"]
-      # and push with redocly cli.
+      unless Rails.env.production?
+        puts "This task is only available for applications in production.".red
+      else
+        if !ENV["BASE_URL"].present?
+          raise "Your BASE_URL must be set before pushing documentation to Redocly."
+        elsif !ENV["REDOCLY_AUTHORIZATION"].present?
+          raise "You need to set your Redocly API key to ENV['REDOCLY_AUTHORIZATION'] so we can push your documentation to Redocly's API Registry."
+        else
+          puts "Before starting, make sure you have already created an API with the base documentation in Redocly's API Registry"
+          puts ""
+
+          puts "Please tell us your organization id.".blue
+          puts "i.e. your-test-app"
+          puts "If you're unsure what this value is, please look at these steps in the documentation:"
+          puts "https://redocly.com/docs/cli/commands/push/#organization-id"
+          puts ""
+
+          organization_id = STDIN.gets.chomp
+          puts ""
+
+          puts "Please tell us your file name.".blue
+          puts "i.e. core@v1"
+          puts "If you're unsure what this value is, please look at these steps in the documentation:"
+          puts "https://redocly.com/docs/cli/commands/push/#api-name"
+          puts ""
+
+          file_name = STDIN.gets.chomp
+          puts ""
+
+          # Validate the file's contents before downloading it.
+          `yarn exec redocly lint #{ENV["BASE_URL"]}/api/v1/openapi.yaml`
+
+          # Get the file.
+          `curl #{ENV["BASE_URL"]}/api/v1/openapi.yaml -o openapi.yaml`
+
+          # Push to Redocly
+          `REDOCLY_AUTHORIZATION=#{ENV["REDOCLY_AUTHORIZATION"]} yarn exec redocly push openapi.yaml @#{organization_id}/#{file_name}`
+
+          # Clean up
+          `rm openapi.yaml`
+        end
+      end
     end
   end
 end

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -11,23 +11,31 @@ namespace :bullet_train do
           puts "Before starting, make sure you have already created an API with the base documentation in Redocly's API Registry"
           puts ""
 
-          puts "Please tell us your organization id.".blue
-          puts "i.e. your-test-app"
-          puts "If you're unsure what this value is, please look at these steps in the documentation:"
-          puts "https://redocly.com/docs/cli/commands/push/#organization-id"
-          puts ""
+          # Grab the organization id and/or file name if provided in parameters.
+          ARGV.shift
+          api_option = ARGV.shift
 
-          organization_id = $stdin.gets.chomp
-          puts ""
+          if api_option.nil? && !(File.exist?(".redocly.yaml") || File.exist?("redocly.yaml"))
+            puts "Please tell us your organization id.".blue
+            puts "i.e. your-test-app"
+            puts "If you're unsure what this value is, please look at these steps in the documentation:"
+            puts "https://redocly.com/docs/cli/commands/push/#organization-id"
+            puts ""
 
-          puts "Please tell us your file name.".blue
-          puts "i.e. core@v1"
-          puts "If you're unsure what this value is, please look at these steps in the documentation:"
-          puts "https://redocly.com/docs/cli/commands/push/#api-name"
-          puts ""
+            organization_id = $stdin.gets.chomp
+            puts ""
 
-          file_name = $stdin.gets.chomp
-          puts ""
+            puts "Please tell us your file name.".blue
+            puts "i.e. core@v1"
+            puts "If you're unsure what this value is, please look at these steps in the documentation:"
+            puts "https://redocly.com/docs/cli/commands/push/#api-name"
+            puts ""
+
+            file_name = $stdin.gets.chomp
+            puts ""
+
+            api_option = "@#{organization_id}/#{file_name}"
+          end
 
           # Validate the file's contents before downloading it.
           `yarn exec redocly lint #{ENV["BASE_URL"]}/api/v1/openapi.yaml`
@@ -36,7 +44,7 @@ namespace :bullet_train do
           `curl #{ENV["BASE_URL"]}/api/v1/openapi.yaml -o openapi.yaml`
 
           # Push to Redocly
-          `REDOCLY_AUTHORIZATION=#{ENV["REDOCLY_AUTHORIZATION"]} yarn exec redocly push openapi.yaml @#{organization_id}/#{file_name}`
+          `REDOCLY_AUTHORIZATION=#{ENV["REDOCLY_AUTHORIZATION"]} yarn exec redocly push openapi.yaml #{api_option}`
 
           # Clean up
           `rm openapi.yaml`

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -1,4 +1,9 @@
-# desc "Explaining what the task does"
-# task :bullet_train_api do
-#   # Task goes here
-# end
+namespace :bullet_train do
+  namespace :api do
+    desc "Registers your production API documentation to Redocly"
+    task :push_to_redocly do
+      # TODO: Generate yaml file with ENV["BASE_URL"]
+      # and push with redocly cli.
+    end
+  end
+end

--- a/lib/tasks/bullet_train/api_tasks.rake
+++ b/lib/tasks/bullet_train/api_tasks.rake
@@ -2,9 +2,7 @@ namespace :bullet_train do
   namespace :api do
     desc "Registers your production API documentation to Redocly"
     task :push_to_redocly do
-      unless Rails.env.production?
-        puts "This task is only available for applications in production.".red
-      else
+      if Rails.env.production?
         if !ENV["BASE_URL"].present?
           raise "Your BASE_URL must be set before pushing documentation to Redocly."
         elsif !ENV["REDOCLY_AUTHORIZATION"].present?
@@ -19,7 +17,7 @@ namespace :bullet_train do
           puts "https://redocly.com/docs/cli/commands/push/#organization-id"
           puts ""
 
-          organization_id = STDIN.gets.chomp
+          organization_id = $stdin.gets.chomp
           puts ""
 
           puts "Please tell us your file name.".blue
@@ -28,7 +26,7 @@ namespace :bullet_train do
           puts "https://redocly.com/docs/cli/commands/push/#api-name"
           puts ""
 
-          file_name = STDIN.gets.chomp
+          file_name = $stdin.gets.chomp
           puts ""
 
           # Validate the file's contents before downloading it.
@@ -43,6 +41,8 @@ namespace :bullet_train do
           # Clean up
           `rm openapi.yaml`
         end
+      else
+        puts "This task is only available for applications in production.".red
       end
     end
   end


### PR DESCRIPTION
Closes #37.

## Details
I found that we needed to generate a file and register it manually first so we can get the following two values:
1. organization id
2. file name

These two are used when pushing updates to the originally registered file. That means developers will have to do that initial setup, but after that they can just use `rake bullet_train:api:push_to_redocly` to push new changes to the docs.

## Automating the organization id and file names
Developers can use a [configuration file](https://redocly.com/docs/cli/commands/push/#set-options-in-the-configuration-file) to omit having to write the organization id and file name each time. I'm thinking of adding this and raising an error when it's not configured.

If you read the configuration docs, you can see that developers can specify specific APIs and file names if they want to, but if they just use `redocly push`, it'll default to what's in the configuration file. I think I'll edit the rake task so it can receive parameters, and then we can just pass those parameters to `redocly push` so developers aren't tied down solely to the configuration file defaults.