### PR TITLE
Fix params for :create and :update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 Gemfile.lock
 yarn.lock
 /node_modules
+/.idea/

--- a/app/controllers/api/open_api_controller.rb
+++ b/app/controllers/api/open_api_controller.rb
@@ -6,6 +6,7 @@ module OpenApiHelper
     lines.unshift(first_line).join.html_safe
   end
 
+  # TODO: Remove this method? It's not being used anywhere
   def components_for(model)
     for_model model do
       indent(render("api/#{@version}/open_api/#{model.name.underscore.pluralize}/components"), 2)

--- a/app/controllers/concerns/api/controllers/base.rb
+++ b/app/controllers/concerns/api/controllers/base.rb
@@ -23,7 +23,7 @@ module Api::Controllers::Base
       uri = URI.parse(url)
       query = Rack::Utils.parse_query(uri.query)
       new_params.each do |key, value|
-        query[key] = value
+        query[key.to_s] = value
       end
       uri.query = Rack::Utils.build_query(query)
       uri.to_s
@@ -35,8 +35,9 @@ module Api::Controllers::Base
       if @pagy.has_more?
         if (collection = instance_variable_get(collection_variable))
           next_cursor = collection.last.id
-          # TODO Probably not great that we're clobbering any `Link` header that might be set.
-          response.headers["Link"] = "<#{modify_url_params(request.url, after: next_cursor)}>; rel=next"
+          link_header = response.headers["Link"]
+          link_value = "<#{modify_url_params(request.url, after: next_cursor)}>; rel=\"next\""
+          response.headers["Link"] = link_header ? "#{link_header}, #{link_value}" : link_value
           response.headers["Pagination-Next"] = next_cursor
         end
       end

--- a/app/views/api/v1/open_api/shared/_paths.yaml.erb
+++ b/app/views/api/v1/open_api/shared/_paths.yaml.erb
@@ -42,6 +42,17 @@
         required: true
         schema:
           type: string
+    requestBody:
+      description: "Information about a new Tangible Thing"
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              scaffolding_completely_concrete_tangible_thing:
+                type: object
+                $ref: "#/components/schemas/ScaffoldingCompletelyConcreteTangibleThingParameters"
     responses:
       "404":
         description: "Not Found"
@@ -50,7 +61,7 @@
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ScaffoldingCompletelyConcreteTangibleThingParameters"
+              $ref: "#/components/schemas/ScaffoldingCompletelyConcreteTangibleThingAttributes"
   <% end %>
 <% end %>
 <% unless except.include?(:show) && except.include?(:update) && except.include?(:destroy) %>
@@ -81,6 +92,17 @@
     operationId: updateScaffoldingCompletelyConcreteTangibleThings
     parameters:
       - $ref: "#/components/parameters/id"
+    requestBody:
+      description: "Information about updated fields in Tangible Thing"
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              scaffolding_completely_concrete_tangible_thing:
+                type: object
+                $ref: "#/components/schemas/ScaffoldingCompletelyConcreteTangibleThingParameters"
     responses:
       "404":
         description: "Not Found"
@@ -89,7 +111,7 @@
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ScaffoldingCompletelyConcreteTangibleThingParameters"
+              $ref: "#/components/schemas/ScaffoldingCompletelyConcreteTangibleThingAttributes"
   <% end %>
   <% unless except.include?(:destroy) %>
   delete:

--- a/app/views/api/v1/open_api/shared/_paths.yaml.erb
+++ b/app/views/api/v1/open_api/shared/_paths.yaml.erb
@@ -13,22 +13,23 @@
         required: true
         schema:
           type: string
+      - $ref: "#/components/parameters/after"
     responses:
       "404":
         description: "Not Found"
       "200":
         description: "OK"
+        headers:
+          Pagination-Next:
+            $ref: "#/components/headers/PaginationNext"
+          Link:
+            $ref: "#/components/headers/Link"
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                data:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/ScaffoldingCompletelyConcreteTangibleThingAttributes"
-                has_more:
-                  type: boolean
+              type: array
+              items:
+                $ref: "#/components/schemas/ScaffoldingCompletelyConcreteTangibleThingAttributes"
   <% end %>
   <% unless except.include?(:create) %>
   post:
@@ -124,7 +125,7 @@
     responses:
       "404":
         description: "Not Found"
-      "200":
-        description: "OK"
+      "204":
+        description: "No Content"
   <% end %>
 <% end %>

--- a/app/views/api/v1/open_api/teams/_paths.yaml.erb
+++ b/app/views/api/v1/open_api/teams/_paths.yaml.erb
@@ -44,6 +44,17 @@
     operationId: updateTeam
     parameters:
       - $ref: "#/components/parameters/id"
+    requestBody:
+      description: "Information about updated fields in Team"
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              team:
+                type: object
+                $ref: "#/components/schemas/TeamParameters"
     responses:
       "404":
         description: "Not Found"
@@ -52,4 +63,4 @@
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TeamParameters"
+              $ref: "#/components/schemas/TeamAttributes"

--- a/app/views/api/v1/open_api/teams/_paths.yaml.erb
+++ b/app/views/api/v1/open_api/teams/_paths.yaml.erb
@@ -4,22 +4,24 @@
       - Teams
     summary: "List Teams"
     operationId: listTeams
+    parameters:
+      - $ref: "#/components/parameters/after"
     responses:
       "404":
         description: "Not Found"
       "200":
         description: "OK"
+        headers:
+          Pagination-Next:
+            $ref: "#/components/headers/PaginationNext"
+          Link:
+            $ref: "#/components/headers/Link"
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                data:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/TeamAttributes"
-                has_more:
-                  type: boolean
+              type: array
+              items:
+                $ref: "#/components/schemas/TeamAttributes"
 /teams/{id}:
   get:
     tags:

--- a/app/views/api/v1/open_api/users/_paths.yaml.erb
+++ b/app/views/api/v1/open_api/users/_paths.yaml.erb
@@ -4,22 +4,24 @@
       - Users
     summary: "List Users"
     operationId: listUsers
+    parameters:
+      - $ref: "#/components/parameters/after"
     responses:
       "404":
         description: "Not Found"
       "200":
         description: "OK"
+        headers:
+          Pagination-Next:
+            $ref: "#/components/headers/PaginationNext"
+          Link:
+            $ref: "#/components/headers/Link"
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                data:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/UserAttributes"
-                has_more:
-                  type: boolean
+              type: array
+              items:
+                $ref: "#/components/schemas/UserAttributes"
 /users/{id}:
   get:
     tags:
@@ -44,6 +46,17 @@
     operationId: updateUser
     parameters:
       - $ref: "#/components/parameters/id"
+    requestBody:
+      description: "Information about updated fields in User"
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              user:
+                type: object
+                $ref: "#/components/schemas/UserParameters"
     responses:
       "404":
         description: "Not Found"
@@ -52,4 +65,4 @@
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserParameters"
+              $ref: "#/components/schemas/UserAttributes"


### PR DESCRIPTION
Closes #43 

- Not sure if we need `description` in `requestBody`
- In OpenAPI 3.1 it's not possible yet to overwrite `required` for the `put` path (https://stackoverflow.com/a/56902241/680820), so the only way now to show parameters for the `put` action the right way (without any required fields) is to duplicate the component in schema, which is too much as for me. I'd better wait 3.2 :)
- I'm not sure at all if we need the object name in the root, because it should be obvious from the root and documentation what we are sending, so another layer of `{ "scaffolding_completely_concrete_tangible_thing": {} }` looks obsolete (as for me again). __Moreover, the responses don't contain this top level object name, so here we have discrepancy between logic of request and response bodies, and those bodies should be unified.__